### PR TITLE
Lock to @solana/web3.js 1.x for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project has received support from the Solana Foundation and Bonk Inu. We ar
 ## Installation
 ```
 npm i @thespidercode/openbook-swap
-npm i @solana/web3.js
+npm i @solana/web3.js@1
 
 *Optional*
 npm install @solana/wallet-adapter-react


### PR DESCRIPTION

Read why, here: https://github.com/solana-labs/solana-web3.js/issues/3498